### PR TITLE
change detection of audio to use sdk instead of pulseaudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Jabra busy light for Linux
 
-This service watch every 5s the status of pulseaudio source link to Jabra headset, when the source became active the busy light is enable.
+This service connects to the Jabra and when it became active (audio is emitted) the busy light is enable.
 
 ## Dependencies
 
-- `pulseaudio` to detect the state of microphone
-- `systemd` to start the service 
+- `systemd` to start the service
 - `jabra-sdk-linux` The linux Jabra SDK [here](https://developer.jabra.com/site/global/sdk/linux/index.gsp)
 
 ```shell
@@ -13,13 +12,13 @@ sudo cp udev/99-jabra.rules /etc/udev/rules.d/99-jabra.rules
 sudo udevadm control --reload
 ```
 
-## Build 
+## Build
 
 ```shell
 CGO_LDFLAGS="-Ljabra-sdk-linux_1.12.2.0/JabraLibLinux/library/ubuntu/64-bit" go build
 ```
 
-## Test 
+## Test
 
 ```shell
 LD_LIBRARY_PATH=jabra-sdk-linux_1.12.2.0/JabraLibLinux/library/ubuntu/64-bit ./jabra-busylight

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module jabra-busylight
 
 go 1.18
-
-require github.com/jfreymuth/pulse v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/jfreymuth/pulse v0.1.0 h1:KN38/9hoF9PJvP5DpEVhMRKNuwnJUonc8c9ARorRXUA=
-github.com/jfreymuth/pulse v0.1.0/go.mod h1:cpYspI6YljhkUf1WLXLLDmeaaPFc3CnGLjDZf9dZ4no=


### PR DESCRIPTION
Because I have no pulseaudio on my system `jabra-busylight` was not working.
I noticed that the JabraSDK provides an event when audio emitting starts and stops.
So I change the code to use this.

I don't know if there is a cause why you did use pulseaudio instead. Is there a cause?